### PR TITLE
:wrench: Add Grype / patch software

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -25,6 +25,6 @@ jobs:
           persist-credentials: false
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: critical

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,11 +25,11 @@ jobs:
 
       - name: Install cosign
         id: install_cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Log in to GitHub Container Registry
         id: login_ghcr
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build and Push
         id: build_and_push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/.github/workflows/scan-image.yml
+++ b/.github/workflows/scan-image.yml
@@ -1,5 +1,5 @@
 ---
-name: Scan Image
+name: Container Scan
 
 on:
   pull_request:
@@ -9,55 +9,10 @@ on:
 permissions: {}
 
 jobs:
-  scan-image:
-    name: Scan Image
-    runs-on: ubuntu-latest
+  container-scan:
+    name: Container Scan
     permissions:
       contents: read
+      pull-requests: write
       security-events: write
-    steps:
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Build Image
-        id: build_image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          push: false
-          load: true
-          tags: analytical-platform-kubectl
-
-      - name: Scan Image
-        id: scan_image
-        run: |
-          cat > trivy-results.sarif << 'EOF'
-          {
-            "version": "2.1.0",
-            "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
-            "runs": [
-              {
-                "tool": {
-                  "driver": {
-                    "name": "trivy-mock"
-                  }
-                },
-                "results": []
-              }
-            ]
-          }
-          EOF
-
-      - name: Upload SARIF
-        if: always()
-        id: upload_sarif
-        uses: github/codeql-action/upload-sarif@fe4161a26a8629af62121b670040955b330f9af2 # v4.31.6
-        with:
-          sarif_file: trivy-results.sarif
-
-      - name: Scan Image (On SARIF Scan Failure)
-        if: failure() && steps.scan_image.outcome == 'failure'
-        id: scan_image_on_failure
-        run: exit 0 # trivy-action step removed
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-container-scan.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1

--- a/.grype.yml
+++ b/.grype.yml
@@ -1,0 +1,10 @@
+---
+# Grype configuration file for container vulnerability scanning
+# https://github.com/anchore/grype#configuration
+
+ignore:
+  - vulnerability: GO-2026-5026
+    reason: "Bundled in upstream kubectl binary; repository is pinned to latest available kubectl patch release."
+
+  - vulnerability: GO-2026-4918
+    reason: "Bundled in upstream kubectl binary; repository is pinned to latest available kubectl patch release."

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,6 +1,0 @@
-# dockerfile
-# HEALTHCHECK instructions have not been added to container images as per dockerfile
-AVD-DS-0026
-
-# zlib: Arbitrary code execution via buffer overflow in untgz utility (alpine 3.23.3, fixed in zlib 1.3.2-r0, no current version above for alpine)
-CVE-2026-22184

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.description="kubectl image for Analytical Platform" \
       org.opencontainers.image.url="https://github.com/ministryofjustice/analytical-platform-kubectl"
 
-ARG KUBECTL_VERSION="v1.35.5"
+ARG KUBECTL_VERSION="v1.36.1"
 
 ENV CONTAINER_GID="10000" \
     CONTAINER_GROUP="nonroot" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # checkov:skip=CKV_DOCKER_2:Healthcheck instructions have not been added to container images
-FROM docker.io/alpine:3.24.1@sha256:20a26477b54fb521bc8f633ea0af1f8f9b3dac5661739f857b381b117226919b
+FROM docker.io/alpine:3.24.1@sha256:79ff19e9084a00eece421b2523fb93e22d730e2c0e525905de047e848e56d95f
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # checkov:skip=CKV_DOCKER_2:Healthcheck instructions have not been added to container images
-FROM docker.io/alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
+FROM docker.io/alpine:3.24.1@sha256:20a26477b54fb521bc8f633ea0af1f8f9b3dac5661739f857b381b117226919b
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # checkov:skip=CKV_DOCKER_2:Healthcheck instructions have not been added to container images
-FROM docker.io/alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+FROM docker.io/alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform" \
@@ -27,7 +27,7 @@ RUN addgroup \
     && mkdir --parents ${CONTAINER_HOME} \
     && chown --recursive ${CONTAINER_USER}:${CONTAINER_GROUP} ${CONTAINER_HOME} \
     && apk add --no-cache --virtual build \
-      curl==8.17.0-r1 \
+      curl==8.19.0-r0 \
     && curl --location "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
       --output /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.description="kubectl image for Analytical Platform" \
       org.opencontainers.image.url="https://github.com/ministryofjustice/analytical-platform-kubectl"
 
-ARG KUBECTL_VERSION="v1.32.13"
+ARG KUBECTL_VERSION="v1.35.5"
 
 ENV CONTAINER_GID="10000" \
     CONTAINER_GROUP="nonroot" \
@@ -27,7 +27,7 @@ RUN addgroup \
     && mkdir --parents ${CONTAINER_HOME} \
     && chown --recursive ${CONTAINER_USER}:${CONTAINER_GROUP} ${CONTAINER_HOME} \
     && apk add --no-cache --virtual build \
-      curl==8.19.0-r0 \
+      curl==8.21.0-r0 \
     && curl --location "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
       --output /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.description="kubectl image for Analytical Platform" \
       org.opencontainers.image.url="https://github.com/ministryofjustice/analytical-platform-kubectl"
 
-ARG KUBECTL_VERSION="v1.36.1"
+ARG KUBECTL_VERSION="v1.36.2"
 
 ENV CONTAINER_GID="10000" \
     CONTAINER_GROUP="nonroot" \

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ docker run -it --rm \
 Generally Dependabot does this, but the following command will return the digest:
 
 ```bash
-docker pull --platform linux/amd64 docker.io/alpine:3.23.4
+docker pull --platform linux/amd64 docker.io/alpine:3.24.1
 
-docker image inspect --format='{{index .RepoDigests 0}}' docker.io/alpine:3.23.4
+docker image inspect --format='{{index .RepoDigests 0}}' docker.io/alpine:3.24.1
 ```
 
 ### APT Packages
@@ -40,7 +40,7 @@ docker image inspect --format='{{index .RepoDigests 0}}' docker.io/alpine:3.23.4
 To find latest APT package versions, you can run the following:
 
 ```bash
-docker run -it --rm --platform linux/amd64 docker.io/alpine:3.23.4
+docker run -it --rm --platform linux/amd64 docker.io/alpine:3.24.1
 
 apk update
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ docker run -it --rm \
 Generally Dependabot does this, but the following command will return the digest:
 
 ```bash
-docker pull --platform linux/amd64 docker.io/alpine:3.23.3
+docker pull --platform linux/amd64 docker.io/alpine:3.23.4
 
-docker image inspect --format='{{index .RepoDigests 0}}' docker.io/alpine:3.23.3
+docker image inspect --format='{{index .RepoDigests 0}}' docker.io/alpine:3.23.4
 ```
 
 ### APT Packages
@@ -40,7 +40,7 @@ docker image inspect --format='{{index .RepoDigests 0}}' docker.io/alpine:3.23.3
 To find latest APT package versions, you can run the following:
 
 ```bash
-docker run -it --rm --platform linux/amd64 docker.io/alpine:3.23.3
+docker run -it --rm --platform linux/amd64 docker.io/alpine:3.23.4
 
 apk update
 

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -8,7 +8,7 @@ commandTests:
   - name: "alpine"
     command: "grep"
     args: ["VERSION_ID", "/etc/os-release"]
-    expectedOutput: ["VERSION_ID=3.23.3"]
+    expectedOutput: ["VERSION_ID=3.23.4"]
 
   - name: "whoami"
     command: "whoami"

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -8,7 +8,7 @@ commandTests:
   - name: "alpine"
     command: "grep"
     args: ["VERSION_ID", "/etc/os-release"]
-    expectedOutput: ["VERSION_ID=3.23.4"]
+    expectedOutput: ["VERSION_ID=3.24.1"]
 
   - name: "whoami"
     command: "whoami"


### PR DESCRIPTION
## Container base image and dependencies

- Upgraded the container base image from Alpine `3.23.3` to Alpine `3.24.1` (with digest pinning) in `Dockerfile`.
- Updated `kubectl` from `v1.32.13` to `v1.36.2` in `Dockerfile`.
- Updated `curl` from `8.17.0-r1` to `8.21.0-r0` in `Dockerfile` for security and compatibility.
- Updated container structure tests to reflect Alpine `3.24.1` in `test/container-structure-test.yml`.
- Updated maintenance guidance for Alpine tag/digest refresh in `README.md`.
- Removed the Trivy ignore file (`.trivyignore`).

## CI/CD workflow improvements

- Refactored image scanning to use the reusable container scan workflow via `.github/workflows/scan-image.yml`.
- Renamed the workflow/job from **Scan Image** to **Container Scan** and updated permissions to include pull request write access for reporting.

## GitHub Actions dependency updates

- Updated `actions/dependency-review-action` to `v5.0.0` in `.github/workflows/dependency-review.yml`.
- Updated `sigstore/cosign-installer` to `v4.1.2` in `.github/workflows/release.yml`.
- Updated `docker/login-action` to `v4.2.0` in `.github/workflows/release.yml`.
- Updated `docker/build-push-action` to `v7.1.0` in `.github/workflows/release.yml`.


Notes on failed scans: 
https://github.com/ministryofjustice/analytical-platform-kubectl/pull/264#issuecomment-4854073550

https://github.com/ministryofjustice/data-platform/issues/485
 