### PR TITLE
:recycle: refactor superlinter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,39 +1,19 @@
 ---
-name: Super-Linter
+name: Super Linter
 
 on:
   pull_request:
     branches:
       - main
-    types:
-      - edited
-      - opened
-      - reopened
-      - synchronize
 
 permissions: {}
 
 jobs:
   super-linter:
-    name: Super-Linter
-    runs-on: ubuntu-latest
+    name: Super Linter
     permissions:
       contents: read
+      packages: read
       statuses: write
-    steps:
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Run Super-Linter
-        id: super_linter
-        uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_BIOME_FORMAT: false
-          VALIDATE_BIOME_LINT: false
-          VALIDATE_TRIVY: false
-          VALIDATE_TRIVY_SBOM: false
+      pull-requests: write
+    uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -17,3 +17,4 @@ jobs:
       statuses: write
       pull-requests: write
     uses: ministryofjustice/analytical-platform-github-actions/.github/workflows/reusable-super-linter.yml@72f9c303ec3becced97e2d4472122fee783ff4a4 # v8.0.1
+    


### PR DESCRIPTION
This pull request updates the configuration for the Super Linter GitHub Actions workflow. The main change is to switch from a local, inline workflow definition to using a reusable workflow provided by the `ministryofjustice/analytical-platform-github-actions` repository. This simplifies maintenance and ensures consistency with shared best practices.

**Workflow configuration updates:**

* Replaces the inline Super Linter job definition with a call to a reusable workflow (`reusable-super-linter.yml`) from an external repository, reducing duplication and manual configuration.
* Updates the workflow and job names from "Super-Linter" to "Super Linter" for consistency.
* Removes explicit step definitions (checkout, linter run, and environment variables) in favor of the reusable workflow's configuration.
* Updates job permissions to include `packages: read` and `pull-requests: write` as required by the reusable workflow.
* Simplifies the workflow trigger by removing specific pull request event types, now triggering on all pull request events to the `main` branch.